### PR TITLE
Add basic WebSocket chat setup using Django Channels

### DIFF
--- a/UA_13XX_bravo/asgi.py
+++ b/UA_13XX_bravo/asgi.py
@@ -11,6 +11,17 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'UA_13XX_bravo.settings')
+from channels.routing import ProtocolTypeRouter, URLRouter
+from django.core.asgi import get_asgi_application
+import communications.routing
 
-application = get_asgi_application()
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "UA_13XX_bravo.settings")
+
+django_asgi_app = get_asgi_application()
+
+application = ProtocolTypeRouter(
+    {
+        "http": django_asgi_app,
+        "websocket": URLRouter(communications.routing.websocket_urlpatterns),
+    }
+)

--- a/UA_13XX_bravo/settings.py
+++ b/UA_13XX_bravo/settings.py
@@ -89,6 +89,8 @@ DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL")
 # Application definition
 
 INSTALLED_APPS = [
+    "daphne",  # for ASGI server
+    "channels",  # for runworker and other channels commands
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -114,6 +116,9 @@ INSTALLED_APPS = [
     "allauth.account",
     "allauth.socialaccount",
 ]
+
+ASGI_APPLICATION = "UA_13XX_bravo.asgi.application"
+
 REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_AUTHENTICATION_CLASSES": (

--- a/communications/chat.py
+++ b/communications/chat.py
@@ -1,0 +1,11 @@
+from channels.generic.websocket import AsyncWebsocketConsumer
+import json
+
+
+class Chat(AsyncWebsocketConsumer):
+    async def connect(self):
+        await self.accept()
+        await self.send(text_data=json.dumps({"message": "Connected!"}))
+
+    async def receive(self, text_data):
+        await self.send(text_data=json.dumps({"echo": text_data}, ensure_ascii=False))

--- a/communications/routing.py
+++ b/communications/routing.py
@@ -1,0 +1,6 @@
+from django.urls import re_path
+from .chat import Chat
+
+websocket_urlpatterns = [
+    re_path(r"ws/chat/$", Chat.as_asgi()),
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,4 +31,5 @@ pillow==9.1.0
 pytest==8.0.0
 django-filter==25.1
 pytest-django==4.5.2
+channels[daphne]==4.2.0
 


### PR DESCRIPTION
- Created Chat in communications/chat.py
- Added routing for ws/chat/ endpoint
- Configured ASGI application for WebSocket support
- Enabled JSON responses with Cyrillic characters (ensure_ascii=False)
- Tested WebSocket with websocat

Proof
![image](https://github.com/user-attachments/assets/41787300-0c5d-46f0-8ab2-516aae1d1102)
